### PR TITLE
upload: show error message if set from server

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "doxa-cli"
-version = "0.1.1"
+version = "0.1.2"
 authors = [
   { name="Jeremy Lo Ying Ping", email="jeremyloyingping@gmail.com" },
 ]

--- a/src/doxa_cli/commands/upload.py
+++ b/src/doxa_cli/commands/upload.py
@@ -24,6 +24,7 @@ from doxa_cli.errors import (
     UploadSlotDeniedError,
 )
 from doxa_cli.utils import (
+    clear_doxa_config,
     compress_submission_directory,
     get_access_token,
     read_doxa_yaml,
@@ -54,6 +55,7 @@ def upload(directory, competition, environment):
         sys.exit(1)
     except SessionExpiredError:
         show_error("\nYour session has expired. Please log in again.")
+        clear_doxa_config()
         sys.exit(1)
     except:
         show_error("\nAn error occurred while performing this command.")
@@ -158,8 +160,12 @@ def upload(directory, competition, environment):
             "ENROLMENT_NOT_FOUND",
             "ENVIRONMENT_NOT_FOUND",
             "STORAGE_NODE_NOT_FOUND",
+            "UNKNOWN",
         ):
             show_error(f"\n{e.doxa_error_message}")
+        elif e.doxa_error_code == "UPLOAD_RATE_LIMIT_REACHED":
+            show_error("\nYour upload could not be processed.\n")
+            click.secho(e.doxa_error_message, bold=True)
         elif e.doxa_error_code == "INVALID_METADATA":
             show_error(
                 "\nYour upload could not be processed; the metadata provided in your `doxa.yaml` file is invalid."

--- a/src/doxa_cli/commands/user.py
+++ b/src/doxa_cli/commands/user.py
@@ -12,6 +12,7 @@ from doxa_cli.errors import (
     SessionExpiredError,
 )
 from doxa_cli.utils import (
+    clear_doxa_config,
     get_access_token,
     print_line,
     show_error,
@@ -45,6 +46,7 @@ def user(extra):
             fg="yellow",
             bold=True,
         )
+        clear_doxa_config()
         sys.exit(1)
     except:
         show_error("\nAn error occurred while performing this command.")


### PR DESCRIPTION
If the server has set an error message and the error isn't one we already have explicit error handling for, we default to showing it.

This is useful as I've just added a rate limiting error in the backend, and the error should be presented as is to the user.